### PR TITLE
Added description for setting in admin pannel

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,4 +1,4 @@
 <?php
 
 $conf['toolbar_inserted_markup'] = '<nspages -h1 -subns -exclude:start>';
-$conf["cache"] = 1;
+$conf['cache'] = 1;

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,4 @@
 <?php
 
 $lang['cache'] = 'Disable the cache';
+$lang['toolbar_inserted_markup'] = 'General syntax';


### PR DESCRIPTION
Since now there is the `setting.php`, I think it would be better to replace the actual (automatic) description `plugin nspages toolbar inserted markup` with the more clearly `General syntax` or something else.