### PR TITLE
Use plural "subnamespaces" where appropriate

### DIFF
--- a/lang/ca/lang.php
+++ b/lang/ca/lang.php
@@ -9,8 +9,8 @@
 $lang['encoding']              = 'utf-8';
 $lang['direction']             = 'ltr';
 $lang['doesntexist']           = 'aquest namespace no existeix: ';
-$lang['subcats']               = 'Subnamespace:';
+$lang['subcats']               = 'Subnamespaces:';
 $lang['pagesinthiscat']        = 'Pàgines en aquest namespace:';
 $lang['continued']             = ' cont.';
 $lang['nopages']               = 'No hi ha pàgines en aquest namespace.';
-$lang['nosubns']               = 'No hi ha subnamespace.';
+$lang['nosubns']               = 'No hi ha subnamespaces.';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -9,8 +9,8 @@
 $lang['encoding']              = 'utf-8';
 $lang['direction']             = 'ltr';
 $lang['doesntexist']           = 'this namespace doesn\'t exist: ';
-$lang['subcats']               = 'Subnamespace:';
+$lang['subcats']               = 'Subnamespaces:';
 $lang['pagesinthiscat']        = 'Pages in this namespace:';
 $lang['continued']             = ' cont.';
 $lang['nopages']               = 'No pages in this namespace.';
-$lang['nosubns']               = 'No subnamespace.';
+$lang['nosubns']               = 'No subnamespaces.';

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -9,8 +9,8 @@
 $lang['encoding']              = 'utf-8';
 $lang['direction']             = 'ltr';
 $lang['doesntexist']           = 'esta sección no existe: ';
-$lang['subcats']               = 'Sección subordinada:';
+$lang['subcats']               = 'Sección subordinadas:';
 $lang['pagesinthiscat']        = 'Páginas en esta sección:';
 $lang['continued']             = ' cont.';
 $lang['nopages']               = 'No hay páginas en esta sección.';
-$lang['nosubns']               = 'No hay sección subordinada.';
+$lang['nosubns']               = 'No hay sección subordinadas.';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -9,8 +9,8 @@
 $lang['encoding']              = 'utf-8';
 $lang['direction']             = 'ltr';
 $lang['doesntexist']           = 'cette catégorie n\'existe pas : ';
-$lang['subcats']               = 'Sous-categories :';
-$lang['pagesinthiscat']        = 'Pages dans la categorie :';
+$lang['subcats']               = 'Sous-catégories :';
+$lang['pagesinthiscat']        = 'Pages dans la catégorie :';
 $lang['continued']             = ' (suite)';
 $lang['nopages']               = 'Pas de pages dans cette catégorie.';
-$lang['nosubns']               = 'Pas de sous-catégorie.';
+$lang['nosubns']               = 'Pas de sous-catégories.';


### PR DESCRIPTION
subcats: "Subnamespace:" looks weird when there are multiple results.
nosubns: "No subnamespaces." sounds more appropriate here.

Also, in lang/fr/lang.php, the remaining "categorie"s are changed to
"catégorie".