### PR TITLE
Fix phpUnit problems

### DIFF
--- a/optionParser.php
+++ b/optionParser.php
@@ -9,7 +9,7 @@ if(!defined('DOKU_INC')) die();
 
 class optionParser {
 
-    function checkRegEx(&$match, $pattern, &$arrayAffected) {
+    static function checkRegEx(&$match, $pattern, &$arrayAffected) {
         optionParser::preg_match_all_wrapper($pattern, $match, $found);
         foreach($found as $regex) {
             $arrayAffected[] = $regex[1];
@@ -22,8 +22,8 @@ class optionParser {
      *
      * @param string $match The string match by the plugin
      * @param string $pattern The pattern which activate the option
-     * @param        $varAffected The variable which will memorise the option
-     * @param        $valIfFound the value affected to the previous variable if the option is found
+     * @param mixed  $varAffected The variable which will memorise the option
+     * @param mixed  $valIfFound the value affected to the previous variable if the option is found
      */
     static function checkOption(&$match, $pattern, &$varAffected, $valIfFound) {
         if(optionParser::preg_match_wrapper($pattern, $match, $found)) {

--- a/syntax.php
+++ b/syntax.php
@@ -35,7 +35,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         return 'substition';
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $return = $this->_getDefaultOptions();
         $return['pos'] = $pos;
 
@@ -96,7 +96,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         );
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         $this->_deactivateTheCacheIfNeeded($renderer);
 
         if ( $data['useLegacySyntax'] ){


### PR DESCRIPTION
These are the messages from phpUnit: 

* Declaration of syntax_plugin_nspages::handle() should be compatible with DokuWiki_Syntax_Plugin::handle
* Declaration of syntax_plugin_nspages::render() should be compatible with DokuWiki_Syntax_Plugin::render
* Non-static method optionParser::checkRegEx() should not be called statically

Also added 'mixed' to the comments on optionParser::checkOption for PhpStorm code inspection

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gturri/nspages/50)
<!-- Reviewable:end -->
