### PR TITLE
added small feature to the (default) column view

### DIFF
--- a/printers/printerNice.php
+++ b/printers/printerNice.php
@@ -42,11 +42,13 @@ class nspages_printerNice extends nspages_printer {
 
         $helper->printHeaderChar($firstCharOfLastAddedPage);
         $helper->openListOfItems();
+        
+        $config_preventBreakCols=true; // this should be changeable via parameter within <nspage...>
 
         $idxCol = 0;
         foreach($tab as $item) {
             //change to the next column if necessary
-            if($nbItemsPrinted == $nbItemPerColumns[$idxCol]) {
+            if($nbItemsPrinted == $nbItemPerColumns[$idxCol] && ($config_preventBreakCols ? ($firstCharOfLastAddedPage != $this->_firstChar($item)):true)) {
                 $idxCol++;
                 $helper->closeListOfItems();
                 $helper->closeColumn();


### PR DESCRIPTION
Added (hardcoded because quickhack) config parameter to tell the plugin to always list all pages unter their beginning letter before breaking into a new column. This feature may come in handy in some cases and could perhaps be extended with somekind of threshold for a hard cap of entries before breaking. If you merge this feature you should embed it with a parameter to enable/disable it within <nspage> tag
