### PR TITLE
Default Picture option is added. Usage: -defaultPicture="Image URL"

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,4 +1,5 @@
 <?php
 
 $conf['toolbar_inserted_markup'] = '<nspages -h1 -subns -exclude:start>';
+$conf['default_picture'] = '';
 $conf['cache'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,4 +1,5 @@
 <?php
 
 $meta['toolbar_inserted_markup'] = array('string');
+$meta['default_picture'] = array('string');
 $meta["cache"] = array("onoff");

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,4 +1,5 @@
 <?php
 
 $lang['cache'] = 'Disable the cache';
+$lang['default_picture'] = 'Set your default picture';
 $lang['toolbar_inserted_markup'] = 'Toolbar inserted markup';

--- a/lang/fa/settings.php
+++ b/lang/fa/settings.php
@@ -4,6 +4,9 @@
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  *
  * @author Sam01 <m.sajad079@gmail.com>
+ * @author Ghassem Tofighi <ghassem@gmail.com>
  */
 $lang['cache']                 = 'غیرفعال کردن کش ';
+$lang['default_picture'] = 'درج تصویر پیش‌فرض';
 $lang['toolbar_inserted_markup'] = 'درج نشانه‌گذار نوار ابزار';
+

--- a/optionParser.php
+++ b/optionParser.php
@@ -85,6 +85,15 @@ class optionParser {
             $varAffected = null;
         }
     }
+    
+    static function checkDefaultPicture(&$match, &$varAffected, $plugin){
+        if(optionParser::preg_match_wrapper("defaultPicture *= *\"([^\"]*)\"", $match, $found)) {
+            $varAffected = $found[1];
+            $match       = optionParser::_removeFromMatch($found[0], $match);
+        } else {
+            $varAffected = null;
+        }
+    }
 
     static function checkExclude(&$match, &$excludedPages, &$excludedNs){
         //--Looking if the syntax -exclude[item1 item2] has been used

--- a/printers/printerPictures.php
+++ b/printers/printerPictures.php
@@ -16,6 +16,7 @@ class nspages_printerPictures extends nspages_printer {
     function __construct($plugin, $mode, $renderer, $data){
         parent::__construct($plugin, $mode, $renderer, $data);
         $this->_displayModificationDate = $data['modificationDateOnPictures'];
+        $this->_defaultPicture = $data['defaultPicture'];
     }
 
     function _print($tab, $type) {
@@ -45,7 +46,11 @@ class nspages_printerPictures extends nspages_printer {
       if ( $picture != "" ){
           return ml($picture, self::$_dims, true);
       } else {
-          return "lib/tpl/dokuwiki/images/logo.png";
+          if ( $this->_defaultPicture == '' ){
+                return "lib/tpl/dokuwiki/images/logo.png";
+          } else {
+		        return ml($this->_defaultPicture, self::$_dims, true);
+          }
       }
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -7,6 +7,7 @@
  * @author  Daniel Schranz <xla@gmx.at>
  * @author  Ignacio Bergmann
  * @author  Andreas Gohr <gohr@cosmocode.de>
+ * @author  Ghassem Tofighi <ghassem@gmail.com>
  */
 if(!defined('DOKU_INC')) die();
 require_once 'printers/printerLineBreak.php';
@@ -78,6 +79,9 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkExclude($match, $return['excludedPages'], $return['excludedNS']);
         optionParser::checkAnchorName($match, $return['anchorName']);
         optionParser::checkActualTitle($match, $return['actualTitleLevel']);
+        optionParser::checkDefaultPicture($match, $return['defaultPicture'], $this);
+
+        
 
         //Now, only the wanted namespace remains in $match
         $nsFinder = new namespaceFinder($match);
@@ -104,7 +108,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
             'natOrder'      => false, 'sortDate' => false,
             'hidenopages'   => false, 'hidenosubns' => false, 'usePictures' => false,
             'modificationDateOnPictures' => false,
-            'sortByCreationDate' => false
+            'sortByCreationDate' => false, 'defaultPicture' => null,
         );
     }
 
@@ -115,6 +119,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         //behave well with the translation plugin (it seems like we cache strings
         //even if the lang doesn't match)
         $this->_denullifyLangOptions($data);
+        $this->_denullifyPictureOptions($data);
         $printer = $this->_selectPrinter($mode, $renderer, $data);
 
         if( ! $this->_isNamespaceUsable($data)){
@@ -132,7 +137,6 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         $printer->printBeginning();
         $this->_print($printer, $data, $subnamespaces, $pages);
         $printer->printEnd();
-
         return TRUE;
     }
 
@@ -143,6 +147,12 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
 
         if ( is_null($data['textPages']) ){
             $data['textPages'] = $this->getLang('pagesinthiscat');
+        }
+    }
+    
+    function _denullifyPictureOptions(&$data){
+        if ( is_null($data['defaultPicture']) ){
+            $data['defaultPicture'] = $this->getConf('default_picture');
         }
     }
 


### PR DESCRIPTION
Dear,
This pull request is for providing an option to add a custom background image for each namespace/page when **-usePictures is activated**. It can be used in the following ways:

1) Adding a global default image for all namespaces and pages. The image URL or image relative path could be added as a global option as you can see in the following image:

<a href="https://ibb.co/mOvCax"><img src="https://preview.ibb.co/cOon8H/nspages_global_options.png" alt="nspages_global_options" border="0"></a><br /><a target='_blank' href='https://imgbb.com/'></a><br />

or it can be used in this way:

<a href="https://ibb.co/b4xm2c"><img src="https://preview.ibb.co/nFEYhc/nspages_global_options_2.png" alt="nspages_global_options_2" border="0"></a>

2) Setting a custom image for each namespace or page on the fly using **-defaultPicture="Image URL"**

<a href="https://ibb.co/bSthax"><img src="https://preview.ibb.co/hiEATH/editor_options.png" alt="editor_options" border="0"></a>

--


 