### PR TITLE
Add -showhidden flag to include pages hidden with hidepages

### DIFF
--- a/fileHelper/fileHelper.php
+++ b/fileHelper/fileHelper.php
@@ -23,7 +23,7 @@ class fileHelper {
             'depth'     => $this->data['maxDepth'], 'keeptxt'=> false, 'listfiles'=> !$this->data['nopages'],
             'listdirs'  => $this->data['subns'], 'pagesonly'=> true, 'skipacl'=> false,
             'sneakyacl' => true, 'hash'=> false, 'meta'=> true, 'showmsg'=> false,
-            'showhidden'=> false, 'firsthead'=> true
+            'showhidden'=> $this->data['showhidden'], 'firsthead'=> true
         );
         $files = array();
         search($files, $conf['datadir'], 'search_universal', $opt, $this->data['wantedDir']);

--- a/syntax.php
+++ b/syntax.php
@@ -61,6 +61,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkOption($match, "sort(By)?CreationDate", $return['sortByCreationDate'], true);
         optionParser::checkOption($match, "hidenopages", $return['hidenopages'], true);
         optionParser::checkOption($match, "hidenosubns", $return['hidenosubns'], true);
+        optionParser::checkOption($match, "showhidden", $return['showhidden'], true);
         optionParser::checkOption($match, "(use)?Pictures?", $return['usePictures'], true);
         optionParser::checkOption($match, "(modification)?Dates?OnPictures?", $return['modificationDateOnPictures'], true);
         optionParser::checkRecurse($match, $return['maxDepth']);
@@ -107,6 +108,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
             'idAndTitle'    => false, 'nbItemsMax' => 0, 'numberedList' => false,
             'natOrder'      => false, 'sortDate' => false,
             'hidenopages'   => false, 'hidenosubns' => false, 'usePictures' => false,
+            'showhidden'    => false,
             'modificationDateOnPictures' => false,
             'sortByCreationDate' => false, 'defaultPicture' => null,
         );


### PR DESCRIPTION
This PR adds new parameter `-showhidden` for **nspages** tag to include pages that are normally excluded from search with the [hidepages](https://www.dokuwiki.org/config:hidepages) config parameter.

This new flag is useful for creating table of contents for hidden namespaces.

Usage example:

`<nspages -showhidden>`