### PR TITLE
Removing unnecessary whitespace at end of listing

### DIFF
--- a/printers/printer.php
+++ b/printers/printer.php
@@ -130,7 +130,7 @@ abstract class nspages_printer {
     function printEnd(){
         //this is needed to make sure everything after the plugin is written below the output
         if($this->mode == 'xhtml') {
-            $this->renderer->doc .= '<br class="catpageeofidx">';
+            $this->renderer->doc .= '<div class="catpageeofidx"></div>';
             $this->renderer->doc .= '</div>';
         } else {
             $this->renderer->linebreak();


### PR DESCRIPTION
Switching to an empty div with the catpageeofidx class to clear the floats, but not introducing an additional empty line