### PR TITLE
Add CSS class to "continued" headers

### DIFF
--- a/printers/rendererXhtmlHelper.php
+++ b/printers/rendererXhtmlHelper.php
@@ -32,7 +32,11 @@ class rendererXhtmlHelper {
 
         $this->renderer->doc .= '<div '
             . $this->fullAnchor($char, $continued)
-            . 'class="catpagechars">' . $text . "</div>\n";
+            . 'class="catpagechars';
+        if ( $continued ){
+            $this->renderer->doc .= ' continued';
+        }
+        $this->renderer->doc .= '">' . $text . "</div>\n";
     }
 
     private function fullAnchor($char, $continued){


### PR DESCRIPTION
Use case: For mobile devices, I display a multi-column list in a single column, where they do not make much sense. Currently there is no way to hide the "continued" headers using CSS.