### PR TITLE
dictionaryOrder option

### DIFF
--- a/optionParser.php
+++ b/optionParser.php
@@ -86,6 +86,15 @@ class optionParser {
         }
     }
     
+    static function checkDictOrder(&$match, &$varAffected, $plugin){
+        if(optionParser::preg_match_wrapper("dict(?:ionary)?Order *= *\"([^\"]*)\"", $match, $found)) {
+            $varAffected = $found[1];
+            $match       = optionParser::_removeFromMatch($found[0], $match);
+        } else {
+            $varAffected = null;
+        }
+    }
+    
     static function checkDefaultPicture(&$match, &$varAffected, $plugin){
         if(optionParser::preg_match_wrapper("defaultPicture *= *\"([^\"]*)\"", $match, $found)) {
             $varAffected = $found[1];

--- a/printers/printer.php
+++ b/printers/printer.php
@@ -76,6 +76,11 @@ abstract class nspages_printer {
     private function _sort(&$tab, $reverse) {
         if ( $this->natOrder ){
             usort($tab, array("nspages_printer", "_natOrder"));
+        } else if ($this->dictOrder) {
+            $oldLocale=setlocale(LC_ALL, 0);
+            setlocale(LC_COLLATE, $this->dictOrder);
+            usort($tab, array("nspages_printer", "_dictOrder"));
+            setlocale(LC_COLLATE, $oldLocale);
         } else {
             usort($tab, array("nspages_printer", "_order"));
         }
@@ -92,6 +97,10 @@ abstract class nspages_printer {
         return strnatcasecmp($p1['sort'], $p2['sort']);
     }
 
+    private static function _dictOrder($p1, $p2) {
+        return strcoll($p1['sort'], $p2['sort']);
+    }
+    
     private function _keepOnlyNMaxItems(&$tab){
         if ($this->nbItemsMax){
             $tab = array_slice($tab, 0, $this->nbItemsMax);

--- a/syntax.php
+++ b/syntax.php
@@ -68,6 +68,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkNbColumns($match, $return['nbCol']);
         optionParser::checkTextPages($match, $return['textPages'], $this);
         optionParser::checkTextNs($match, $return['textNS'], $this);
+        optionParser::checkDictOrder($match, $return['dictOrder'], $this);
         optionParser::checkRegEx($match, "pregPages?On=\"([^\"]*)\"", $return['pregPagesOn']);
         optionParser::checkRegEx($match, "pregPages?Off=\"([^\"]*)\"", $return['pregPagesOff']);
         optionParser::checkRegEx($match, "pregPages?TitleOn=\"([^\"]*)\"", $return['pregPagesTitleOn']);
@@ -108,7 +109,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
             'idAndTitle'    => false, 'nbItemsMax' => 0, 'numberedList' => false,
             'natOrder'      => false, 'sortDate' => false,
             'hidenopages'   => false, 'hidenosubns' => false, 'usePictures' => false,
-            'showhidden'    => false,
+            'showhidden'    => false, 'dictOrder' => false,
             'modificationDateOnPictures' => false,
             'sortByCreationDate' => false, 'defaultPicture' => null,
         );


### PR DESCRIPTION
Hi Guillaume

I've merged all changes in this new pull request.

Now, activating option: 

`-dictionaryOrder="es_ES.utf8"`

sorts accented words for the specified language as in a dictionary (in this example, spanish).

P.S.
It would be possible and very easy to check if the specified locale is available. See:
`print_r(ResourceBundle::getLocales(''));`
By the way I don't know how to rise a warning within a plugin.



