### PR TITLE
Exclude Fixes

### DIFF
--- a/fileHelper/pagePreparer.php
+++ b/fileHelper/pagePreparer.php
@@ -23,11 +23,15 @@ class pagePreparer extends filePreparer {
 
     private function passSubNsfilterInRecursiveMode($file){
         $subNss = explode(':', $file['id']);
-        if ( count($subNss) <= 2 ){ //It means we're not in recursive mode
+        if ( count($subNss) < 2 ){ //It means we're not in recursive mode
             return true;
         }
-        $firstChildSubns = $subNss[1];
-        return !in_array($firstChildSubns, $this->excludedNs);
+        for ($i = 0; $i < count($subNss) - 1; $i++) {
+            if (in_array($subNss[$i], $this->excludedNs)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     function prepareFile(&$page){

--- a/optionParser.php
+++ b/optionParser.php
@@ -111,7 +111,7 @@ class optionParser {
             $found = explode(' ', $found[1]);
             foreach($found as $item) {
                 if($item[strlen($item) - 1] == ':') { //not utf8_strlen() on purpose
-                    $excludedNS[] = utf8_substr($item, 0, -1);
+                    $excludedNs[] = utf8_substr($item, 0, -1);
                 } else {
                     $excludedPages[] = $item;
                 }


### PR DESCRIPTION
This fixes issues with excluding namespaces:
- Multi exclude syntax `-exclude:[page1 subNs: page2]` would ignore namespace excludes
- Using recursive would only apply namespace exclude to one namespace of a page's path but only if there were multiple namespaces. (E.g. `ns1:ns2:page` would be excluded with `-exclude:ns2:` but not `-exclude:ns1:` nor would `ns1:page` work) This should fix the issue described in #88. 