### PR TITLE
add custom title support for simple lists

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -3,3 +3,4 @@
 $conf['toolbar_inserted_markup'] = '<nspages -h1 -subns -exclude:start>';
 $conf['default_picture'] = '';
 $conf['cache'] = 1;
+$conf['custom_title_allow_list_metadata'] = 'title, user';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,3 +3,4 @@
 $meta['toolbar_inserted_markup'] = array('string');
 $meta['default_picture'] = array('string');
 $meta["cache"] = array("onoff");
+$meta["custom_title_allow_list_metadata"] = array("string");

--- a/fileHelper/fileHelper.php
+++ b/fileHelper/fileHelper.php
@@ -31,12 +31,12 @@ class fileHelper {
     }
 
     function getPages(){
-        $preparer = new pagePreparer($this->data['excludedNS'], $this->data['excludedPages'], $this->data['pregPagesOn'], $this->data['pregPagesOff'], $this->data['pregPagesTitleOn'], $this->data['pregPagesTitleOff'], $this->data['title'], $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate']);
+        $preparer = new pagePreparer($this->data['excludedNS'], $this->data['excludedPages'], $this->data['pregPagesOn'], $this->data['pregPagesOff'], $this->data['pregPagesTitleOn'], $this->data['pregPagesTitleOff'], $this->data['title'], $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate'], $this->data['customTitle']);
         return $this->getFiles($preparer);
     }
 
     function getSubnamespaces(){
-        $preparer = new namespacePreparer($this->data['excludedNS'], $this->data['pregNSOn'], $this->data['pregNSOff'], $this->data['pregNSTitleOn'], $this->data['pregNSTitleOff'], $this->data['title'], $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate']);
+        $preparer = new namespacePreparer($this->data['excludedNS'], $this->data['pregNSOn'], $this->data['pregNSOff'], $this->data['pregNSTitleOn'], $this->data['pregNSTitleOff'], $this->data['title'], $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate'], $this->data['customTitle']);
         return $this->getFiles($preparer);
     }
 

--- a/fileHelper/fileHelper.php
+++ b/fileHelper/fileHelper.php
@@ -12,9 +12,12 @@ class fileHelper {
     private $files;
     private $data;
 
-    function __construct($data){
+    private $customTitleAllowListMetadata;
+
+    function __construct($data, $customTitleAllowListMetadata){
         $this->data = $data;
         $this->files = $this->searchFiles($data);
+        $this->customTitleAllowListMetadata = $customTitleAllowListMetadata;
     }
 
     private function searchFiles(){
@@ -31,12 +34,17 @@ class fileHelper {
     }
 
     function getPages(){
-        $preparer = new pagePreparer($this->data['excludedNS'], $this->data['excludedPages'], $this->data['pregPagesOn'], $this->data['pregPagesOff'], $this->data['pregPagesTitleOn'], $this->data['pregPagesTitleOff'], $this->data['title'], $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate'], $this->data['customTitle']);
+        $preparer = new pagePreparer($this->data['excludedNS'], $this->data['excludedPages'], $this->data['pregPagesOn'],
+            $this->data['pregPagesOff'], $this->data['pregPagesTitleOn'], $this->data['pregPagesTitleOff'], $this->data['title'],
+            $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate'],
+            $this->data['customTitle'], $this->customTitleAllowListMetadata);
         return $this->getFiles($preparer);
     }
 
     function getSubnamespaces(){
-        $preparer = new namespacePreparer($this->data['excludedNS'], $this->data['pregNSOn'], $this->data['pregNSOff'], $this->data['pregNSTitleOn'], $this->data['pregNSTitleOff'], $this->data['title'], $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate'], $this->data['customTitle']);
+        $preparer = new namespacePreparer($this->data['excludedNS'], $this->data['pregNSOn'], $this->data['pregNSOff'],
+            $this->data['pregNSTitleOn'], $this->data['pregNSTitleOff'], $this->data['title'], $this->data['sortid'],
+            $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate']);
         return $this->getFiles($preparer);
     }
 

--- a/fileHelper/filePreparer.php
+++ b/fileHelper/filePreparer.php
@@ -29,12 +29,14 @@ abstract class filePreparer {
     protected $sortPageByDate;
     protected $sortByCreationDate;
 
+    protected $customTitle;
+
     /**
      * bool
      */
     protected $sortPageById;
 
-    function __construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate){
+    function __construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle){
         $this->excludedFiles = $excludedFiles;
         $this->pregOn = $pregOn;
         $this->pregOff = $pregOff;
@@ -45,6 +47,7 @@ abstract class filePreparer {
         $this->useIdAndTitle = $useIdAndTitle;
         $this->sortPageByDate = $sortPageByDate;
         $this->sortByCreationDate = $sortByCreationDate;
+        $this->customTitle = $customTitle;
     }
 
     function isFileWanted($file, $useTitle) {

--- a/fileHelper/filePreparer.php
+++ b/fileHelper/filePreparer.php
@@ -30,13 +30,15 @@ abstract class filePreparer {
     protected $sortByCreationDate;
 
     protected $customTitle;
+    protected $customTitleAllowListMetadata;
 
     /**
      * bool
      */
     protected $sortPageById;
 
-    function __construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle){
+    function __construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById,
+                         $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle, $customTitleAllowListMetadata){
         $this->excludedFiles = $excludedFiles;
         $this->pregOn = $pregOn;
         $this->pregOff = $pregOff;
@@ -48,6 +50,7 @@ abstract class filePreparer {
         $this->sortPageByDate = $sortPageByDate;
         $this->sortByCreationDate = $sortByCreationDate;
         $this->customTitle = $customTitle;
+        $this->customTitleAllowListMetadata = $customTitleAllowListMetadata;
     }
 
     function isFileWanted($file, $useTitle) {

--- a/fileHelper/namespacePreparer.php
+++ b/fileHelper/namespacePreparer.php
@@ -9,7 +9,7 @@ require_once 'filePreparer.php';
 
 class namespacePreparer extends filePreparer {
     function __construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate){
-        parent::__construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate);
+        parent::__construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, null);
     }
 
     function isFileWanted($file, $useTitle){

--- a/fileHelper/namespacePreparer.php
+++ b/fileHelper/namespacePreparer.php
@@ -9,7 +9,7 @@ require_once 'filePreparer.php';
 
 class namespacePreparer extends filePreparer {
     function __construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate){
-        parent::__construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, null);
+        parent::__construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, null, null);
     }
 
     function isFileWanted($file, $useTitle){

--- a/fileHelper/pagePreparer.php
+++ b/fileHelper/pagePreparer.php
@@ -9,8 +9,10 @@ require_once 'filePreparer.php';
 
 class pagePreparer extends filePreparer {
 
-    function __construct($excludedNs, $excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle){
-        parent::__construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle);
+    function __construct($excludedNs, $excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle,
+                         $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle, $customTitleAllowListMetadata){
+        parent::__construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById,
+            $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle, $customTitleAllowListMetadata);
         $this->excludedNs = $excludedNs;
     }
 
@@ -62,6 +64,11 @@ class pagePreparer extends filePreparer {
         );
     }
 
+    private function isPathInMetadataAllowList($path) {
+        $metadataAllowList = explode(',', preg_replace('/\s+/', '', $this->customTitleAllowListMetadata));
+        return in_array($path, $metadataAllowList);
+    }
+
     /**
      * Get the page custom title from a template.
      *
@@ -77,7 +84,12 @@ class pagePreparer extends filePreparer {
         return preg_replace_callback(
             '/{(.*?)}/',
             function ($matches) use($metadata) {
-                return $this->getMetadataFromPath($metadata, $matches[1]);
+                $path = $matches[1];
+                if ($this->isPathInMetadataAllowList($path)) {
+                    return $this->getMetadataFromPath($metadata, $path);
+                } else {
+                    return $path;
+                }
             },
             $customTitle
         );

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,3 +3,4 @@
 $lang['cache'] = 'Disable the cache';
 $lang['default_picture'] = 'Set your default picture';
 $lang['toolbar_inserted_markup'] = 'Toolbar inserted markup';
+$lang['custom_title_allow_list_metadata'] = 'Custom title allow list metadata';

--- a/optionParser.php
+++ b/optionParser.php
@@ -77,6 +77,15 @@ class optionParser {
         }
     }
 
+    static function checkCustomTitle(&$match, &$varAffected, $plugin){
+        if(optionParser::preg_match_wrapper("customTitle? *= *\"([^\"]*)\"", $match, $found)) {
+            $varAffected = $found[1];
+            $match       = optionParser::_removeFromMatch($found[0], $match);
+        } else {
+            $varAffected = null;
+        }
+    }
+
     static function checkTextNs(&$match, &$varAffected, $plugin){
         if(optionParser::preg_match_wrapper("textNS *= *\"([^\"]*)\"", $match, $found)) {
             $varAffected = $found[1];

--- a/syntax.php
+++ b/syntax.php
@@ -138,7 +138,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
             return TRUE;
         }
 
-        $fileHelper = new fileHelper($data);
+        $fileHelper = new fileHelper($data, $this->getConf('custom_title_allow_list_metadata'));
         $pages = $fileHelper->getPages();
         $subnamespaces = $fileHelper->getSubnamespaces();
         if ( $this->_shouldPrintPagesAmongNamespaces($data) ){

--- a/syntax.php
+++ b/syntax.php
@@ -70,6 +70,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkRecurse($match, $return['maxDepth']);
         optionParser::checkNbColumns($match, $return['nbCol']);
         optionParser::checkTextPages($match, $return['textPages'], $this);
+        optionParser::checkCustomTitle($match, $return['customTitle'], $this);
         optionParser::checkTextNs($match, $return['textNS'], $this);
         optionParser::checkDictOrder($match, $return['dictOrder'], $this);
         optionParser::checkRegEx($match, "pregPages?On=\"([^\"]*)\"", $return['pregPagesOn']);
@@ -101,6 +102,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
             'excludedPages' => array(), 'excludedNS' => array(),
             'title'         => false, 'wantedNS' => '', 'wantedDir' => '', 'safe' => true,
             'textNS'        => '', 'textPages' => '', 'pregPagesOn' => array(),
+            'customTitle'   => '',
             'pregPagesOff'  => array(), 'pregNSOn' => array(), 'pregNSOff' => array(),
             'pregPagesTitleOn' => array(), 'pregPagesTitleOff' => array(),
             'pregNSTitleOn' => array(), 'pregNSTitleOff' => array(),


### PR DESCRIPTION
This is the first time I am using DokuWiki and I wanted to print all pages from a namespace. 

The nspages plugin is pretty good, but I wanted to list all pages in a simple list with my custom title. At this moment I only saw the "-h1" option that was not enough for me.

This PR adds support for a new parameter (-customTitle) and the value of this parameter should be the template of the title. Examples:
`<nspages :my-namespace -customTitle="{title} ({year}) by {user}">`
This will list the pages like this:
- Title Page 1 (2020) by florin
- Title Page 2 (2021) by florin

`<nspages :my-namespace -customTitle="{title} ({customMeta}) at {date.created}">`
This example will list the pages like this:
- Title Page 1 (something) at 1613325505
- Title Page 2 (something) at 1613325528

It can be use in conjustion with another plugins that adds support for custom metadatas (like [plugin:meta](https://www.dokuwiki.org/plugin:meta)). In my case "year" and "customMeta" are custom metadatas. If you don't have any custom metadatas you can easily access the default metadatas that are documented [here](https://www.dokuwiki.org/devel:metadata) (in my examples, "year" and "date.created" are default metadatas) .
