### PR TITLE
add support for sort by metadata

### DIFF
--- a/fileHelper/fileHelper.php
+++ b/fileHelper/fileHelper.php
@@ -37,7 +37,7 @@ class fileHelper {
         $preparer = new pagePreparer($this->data['excludedNS'], $this->data['excludedPages'], $this->data['pregPagesOn'],
             $this->data['pregPagesOff'], $this->data['pregPagesTitleOn'], $this->data['pregPagesTitleOff'], $this->data['title'],
             $this->data['sortid'], $this->data['idAndTitle'], $this->data['sortDate'], $this->data['sortByCreationDate'],
-            $this->data['customTitle'], $this->customTitleAllowListMetadata);
+            $this->data['customTitle'], $this->customTitleAllowListMetadata, $this->data['sortByMetadata']);
         return $this->getFiles($preparer);
     }
 

--- a/fileHelper/pagePreparer.php
+++ b/fileHelper/pagePreparer.php
@@ -8,16 +8,21 @@ if(!defined('DOKU_INC')) die();
 require_once 'filePreparer.php';
 
 class pagePreparer extends filePreparer {
+
     private $customTitle;
     private $customTitleAllowListMetadata;
+    private $sortByMetadata;
 
     function __construct($excludedNs, $excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle,
-                         $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle, $customTitleAllowListMetadata){
+                         $sortPageById, $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle,
+                         $customTitleAllowListMetadata, $sortByMetadata) {
         parent::__construct($excludedFiles, $pregOn, $pregOff, $pregTitleOn, $pregTitleOff, $useTitle, $sortPageById,
-            $useIdAndTitle, $sortPageByDate, $sortByCreationDate, $customTitle, $customTitleAllowListMetadata);
+            $useIdAndTitle, $sortPageByDate, $sortByCreationDate);
+
         $this->excludedNs = $excludedNs;
         $this->customTitle = $customTitle;
         $this->customTitleAllowListMetadata = $customTitleAllowListMetadata;
+        $this->sortByMetadata = $sortByMetadata;
     }
 
     function isFileWanted($file, $useTitle){
@@ -120,11 +125,14 @@ class pagePreparer extends filePreparer {
     }
 
     private function buildSortAttribute($nameToDisplay, $pageId, $mtime){
-        if($this->sortPageById) {
+        if ($this->sortByMetadata !== null) {
+            $meta = p_get_metadata($pageId);
+            return $this->getMetadataFromPath($meta, $this->sortByMetadata);
+        } else if($this->sortPageById) {
             return noNS($pageId);
-        } else if ( $this->sortPageByDate ){
+        } else if ( $this->sortPageByDate) {
             return $mtime;
-        } else if ($this->sortByCreationDate ){
+        } else if ($this->sortByCreationDate) {
             $meta = p_get_metadata($pageId);
             return $meta['date']['created'];
         } else {

--- a/optionParser.php
+++ b/optionParser.php
@@ -68,26 +68,8 @@ class optionParser {
         }
     }
 
-    static function checkTextPages(&$match, &$varAffected, $plugin){
-        if(optionParser::preg_match_wrapper("textPages? *= *\"([^\"]*)\"", $match, $found)) {
-            $varAffected = $found[1];
-            $match       = optionParser::_removeFromMatch($found[0], $match);
-        } else {
-            $varAffected = null;
-        }
-    }
-
-    static function checkCustomTitle(&$match, &$varAffected, $plugin){
-        if(optionParser::preg_match_wrapper("customTitle? *= *\"([^\"]*)\"", $match, $found)) {
-            $varAffected = $found[1];
-            $match       = optionParser::_removeFromMatch($found[0], $match);
-        } else {
-            $varAffected = null;
-        }
-    }
-
-    static function checkTextNs(&$match, &$varAffected, $plugin){
-        if(optionParser::preg_match_wrapper("textNS *= *\"([^\"]*)\"", $match, $found)) {
+    static function checkSimpleStringArgument(&$match, &$varAffected, $plugin, $argumentName){
+        if(optionParser::preg_match_wrapper($argumentName . " *= *\"([^\"]*)\"", $match, $found)) {
             $varAffected = $found[1];
             $match       = optionParser::_removeFromMatch($found[0], $match);
         } else {
@@ -97,15 +79,6 @@ class optionParser {
 
     static function checkDictOrder(&$match, &$varAffected, $plugin){
         if(optionParser::preg_match_wrapper("dict(?:ionary)?Order *= *\"([^\"]*)\"", $match, $found)) {
-            $varAffected = $found[1];
-            $match       = optionParser::_removeFromMatch($found[0], $match);
-        } else {
-            $varAffected = null;
-        }
-    }
-
-    static function checkDefaultPicture(&$match, &$varAffected, $plugin){
-        if(optionParser::preg_match_wrapper("defaultPicture *= *\"([^\"]*)\"", $match, $found)) {
             $varAffected = $found[1];
             $match       = optionParser::_removeFromMatch($found[0], $match);
         } else {

--- a/syntax.php
+++ b/syntax.php
@@ -69,9 +69,10 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkOption($match, "displayModificationDates?", $return["displayModificationDate"], true);
         optionParser::checkRecurse($match, $return['maxDepth']);
         optionParser::checkNbColumns($match, $return['nbCol']);
-        optionParser::checkTextPages($match, $return['textPages'], $this);
-        optionParser::checkCustomTitle($match, $return['customTitle'], $this);
-        optionParser::checkTextNs($match, $return['textNS'], $this);
+        optionParser::checkSimpleStringArgument($match, $return['textPages'], $this, 'textPages');
+        optionParser::checkSimpleStringArgument($match, $return['customTitle'], $this, 'customTitle');
+        optionParser::checkSimpleStringArgument($match, $return['sortByMetadata'], $this, 'sortByMetadata');
+        optionParser::checkSimpleStringArgument($match, $return['textNS'], $this, 'textNS');
         optionParser::checkDictOrder($match, $return['dictOrder'], $this);
         optionParser::checkRegEx($match, "pregPages?On=\"([^\"]*)\"", $return['pregPagesOn']);
         optionParser::checkRegEx($match, "pregPages?Off=\"([^\"]*)\"", $return['pregPagesOff']);
@@ -85,7 +86,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkExclude($match, $return['excludedPages'], $return['excludedNS']);
         optionParser::checkAnchorName($match, $return['anchorName']);
         optionParser::checkActualTitle($match, $return['actualTitleLevel']);
-        optionParser::checkDefaultPicture($match, $return['defaultPicture'], $this);
+        optionParser::checkSimpleStringArgument($match, $return['defaultPicture'], $this, 'defaultPicture');
 
         //Now, only the wanted namespace remains in $match
         $nsFinder = new namespaceFinder($match);


### PR DESCRIPTION
this is a follow up for a previous PR - https://github.com/gturri/nspages/pull/112

now you can order the simple list by a metadata

examples:
`<nspages :my-namespace -textPages="" -simpleList -customTitle="{title} ({year})" -sortByMetadata="year" -reverse>`

`<nspages :my-namespace -textPages="" -simpleList -customTitle="{title} ({year})" -sortByMetadata="date.created">`