### PR TITLE
Prevent optionParser::_removeFromMatch removing prefixes of later opt…

### DIFF
--- a/optionParser.php
+++ b/optionParser.php
@@ -149,6 +149,6 @@ class optionParser {
     }
 
     static private function _removeFromMatch($matched, $match){
-        return str_replace($matched, ' ', $match);
+        return substr(str_replace($matched.' ', ' ', $match.' '), 0, -1);
     }
 }


### PR DESCRIPTION
…ions

This fixes the case where an option is a prefix of another option, e.g.:

`<nspages -exclude -exclude:page1 -exclude:page10>`

When parsing ` -exclude:page1` (most options are matched with a leading space), the above would remove both instances of the string leaving an invalid `0`:

`<nspages -exclude 0>`

This can be circumvented by sorting all options by length descending, but this should not be required of the user.