### PR TITLE
Include all whitespace when removing matched option

### DIFF
--- a/optionParser.php
+++ b/optionParser.php
@@ -162,6 +162,8 @@ class optionParser {
 
     static private function _removeFromMatch($matched, $match){
         $matched = trim($matched); // to handle the case of the option "-r" which already matches an extra whitespace
-        return substr(str_replace($matched.' ', ' ', $match.' '), 0, -1);
+        // Matched option including any leading and trailing whitespace
+        $regex = '/\s*' . preg_quote($matched, '/') . '\s*/';
+        return preg_replace($regex, ' ', $match);
     }
 }


### PR DESCRIPTION
Previously, only space was considered. This caused error when the nspages tag spanned multiple lines and there was no trailing space before the newline.

Fixes #153