### PR TITLE
Include all whitespace when removing matched option (take 2)

### DIFF
--- a/optionParser.php
+++ b/optionParser.php
@@ -162,7 +162,8 @@ class optionParser {
 
     static private function _removeFromMatch($matched, $match){
         $matched = trim($matched); // to handle the case of the option "-r" which already matches an extra whitespace
-        $match = substr(str_replace($matched.' ', ' ', $match.' '), 0, -1);
-        return substr(str_replace($matched."\n", ' ', $match.' '), 0, -1);
+        // Matched option including any leading and at least one trailing whitespace
+        $regex = '/\s*' . preg_quote($matched, '/') . '\s+/';
+        return preg_replace($regex, ' ', $match);
     }
 }


### PR DESCRIPTION
Previously, only space was considered. This caused error when the nspages tag spanned multiple lines and there was no trailing space before the newline.

Fixes #153 without breaking #123 (see https://github.com/gturri/nspages/issues/153#issuecomment-1722018996)

This is basically the same fix as initially proposed in #154, the only difference is the pattern changed from `\s*` to `\s+` to require at least one whitespace after the match.