### PR TITLE
Add HideNoNs option

### DIFF
--- a/_tests/src/test/java/nspages/Test_hideNoNs.java
+++ b/_tests/src/test/java/nspages/Test_hideNoNs.java
@@ -1,0 +1,35 @@
+package nspages;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class Test_hideNoNs extends Helper {
+	@Test
+	public void withoutOption(){
+		generatePage("noitems:start", "<nspages -exclude nonexistent>");
+
+		List<WebElement> sections = getDriver().findElements(By.className("catpageheadline"));
+		assertEquals(0, sections.size());
+
+		//Without this assert, the test would succeed even without the implementation commit
+		assertTrue(pagesContains("namespace doesn't exist:"));
+	}
+
+	@Test
+	public void withOption(){
+		generatePage("noitems:start", "<nspages -exclude -hideNoNs nonexistent>");
+
+		List<WebElement> sections = getDriver().findElements(By.className("catpageheadline"));
+		assertEquals(0, sections.size());
+
+		//Without this assert, the test would succeed even without the implementation commit
+		assertFalse(pagesContains("namespace doesn't exist:"));
+	}
+}

--- a/syntax.php
+++ b/syntax.php
@@ -65,6 +65,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         optionParser::checkOption($match, "sort(By)?Date", $return['sortDate'], true);
         optionParser::checkOption($match, "sort(By)?CreationDate", $return['sortByCreationDate'], true);
         optionParser::checkOption($match, "hidenopages", $return['hidenopages'], true);
+        optionParser::checkOption($match, "hidenons", $return['hidenons'], true);
         optionParser::checkOption($match, "hidenosubns", $return['hidenosubns'], true);
         optionParser::checkOption($match, "showhidden", $return['showhidden'], true);
         optionParser::checkOption($match, "(use)?Pictures?", $return['usePictures'], true);
@@ -124,7 +125,7 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
             'pagesinns'     => false, 'anchorName' => null, 'actualTitleLevel' => false,
             'idAndTitle'    => false, 'nbItemsMax' => 0, 'numberedList' => false,
             'natOrder'      => false, 'sortDate' => false,
-            'hidenopages'   => false, 'hidenosubns' => false, 'usePictures' => false,
+            'hidenopages'   => false, 'hidenons' => false, 'hidenosubns' => false, 'usePictures' => false,
             'showhidden'    => false, 'dictOrder' => false,
             'modificationDateOnPictures' => false,
             'displayModificationDate' => false,
@@ -165,8 +166,11 @@ class syntax_plugin_nspages extends DokuWiki_Syntax_Plugin {
         }
 
 
-        if( ! $this->_isNamespaceUsable($data)){
-            $printer->printUnusableNamespace($data['wantedNS']);
+        if( ! $this->_isNamespaceUsable($data))
+        {
+            if( ! $data['hidenons']) {
+                $printer->printUnusableNamespace($data['wantedNS']);
+            }
             return TRUE;
         }
 


### PR DESCRIPTION
By default nspages provides a warning "namespace doesn't exist". This is
usually what is wanted. Sometimes users will want to hide this warning -
for example with generated files which contain a ToC for a namespace which
may not yet have been created.

This PR adds a new option "-hideNoNs" which implements this﻿
